### PR TITLE
Simple import handling for when flowslicer is installed as a package

### DIFF
--- a/flowslicer.py
+++ b/flowslicer.py
@@ -16,8 +16,12 @@ from binaryninja import flowgraph, BranchType, HighLevelILOperation
 
 from collections.abc import Mapping
 
-import db
-from dfil import DataNode, DataFlowEdge, TokenExpression
+try:
+    import db
+    from dfil import DataNode, DataFlowEdge, TokenExpression
+except ImportError:
+    import flowslicer.db as db
+    from flowslicer.dfil import DataNode, DataFlowEdge, TokenExpression
 
 try:
     from .dfil import *


### PR DESCRIPTION
Allows `python -c “import flowslicer”` to be run from either the local directory without any package installation (existing functionality) as well as supporting flowslicer to be installed as a package to be run anywhere (new functionality).

This PR does not include the `setup.py` file necessary for generating the package as I installed this as a submodule within a separate package using `setuptools.find_packages()`. See [this example](https://github.com/riverloopsec/hashashin/blob/140c8a66a61ae88e965f0006320c54de4e9658de/setup.py#L51) to see how I included `flowslicer` within my own `setup.py`. 
Note, a better/clearer change would be to set up flowslicer to be a python package such that the `try` block is unnecessary but I did not want this PR to change any existing functionality, only to add new.